### PR TITLE
Use environment variable substitution instead of sed to pass tags

### DIFF
--- a/.github/actions/build-child-devcontainer/action.yaml
+++ b/.github/actions/build-child-devcontainer/action.yaml
@@ -1,5 +1,5 @@
-name: Publish devcontainer
-description: Build and publish a devcontainer
+name: Build child devcontainer
+description: Build and optionally push a child devcontainer image
 inputs:
   image:
     description: Name of the image to build
@@ -25,14 +25,6 @@ inputs:
 runs:
   using: composite
   steps:
-
-    - name: Log in to registry
-      if: inputs.push-image == 'true'
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
 
     - name: Download base image artifact
       if: inputs.push-image != 'true'
@@ -85,13 +77,12 @@ runs:
         echo "tags=$TAGS" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Build devcontainer image
-      uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
-      env:
-        BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}
+    - name: Build image
+      uses: ./.github/actions/build-devcontainer
       with:
-        imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
-        imageTag: ${{ steps.augment-tags.outputs.tags }}
-        push: ${{ inputs.push-image == 'true' && 'always' || 'never' }}
-        subFolder: ./src/${{ inputs.image }}
-        cacheFrom: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
+        image: ${{ inputs.image }}
+        image-tags: ${{ steps.augment-tags.outputs.tags }}
+        base-image-tag: ${{ inputs.base-image-tag }}
+        push-image: ${{ inputs.push-image }}
+        registry: ${{ inputs.registry }}
+        github-token: ${{ inputs.github-token }}

--- a/.github/actions/build-devcontainer/action.yaml
+++ b/.github/actions/build-devcontainer/action.yaml
@@ -1,0 +1,47 @@
+name: Build devcontainer
+description: Build and optionally push a devcontainer image
+inputs:
+  image:
+    description: Name of the image to build
+    required: true
+  image-tags:
+    description: Comma-separated tags to apply to the image
+    required: true
+  push-image:
+    description: Push the built image to the registry
+    required: false
+    default: 'false'
+  base-image-tag:
+    description: Base image tag (set as BASE_IMAGE_TAG env var during build)
+    required: false
+    default: ''
+  registry:
+    description: 'Docker registry'
+    required: false
+    default: ghcr.io
+  github-token:
+    description: GitHub token
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: Log in to registry
+      if: inputs.push-image == 'true'
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ github.actor }}
+        password: ${{ inputs.github-token }}
+
+    - name: Build devcontainer image
+      uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
+      env:
+        BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}
+      with:
+        imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
+        imageTag: ${{ inputs.image-tags }}
+        push: ${{ inputs.push-image == 'true' && 'always' || 'never' }}
+        subFolder: ./src/${{ inputs.image }}
+        cacheFrom: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -91,11 +91,11 @@ runs:
         echo "tags=$TAGS" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Set base image tag
+    - name: Determine base image tag
       id: set-base-image-tag
       run: |
         FIRST_TAG=$(echo "${{ steps.extract-tag-parts.outputs.tags }}" | cut -d',' -f1)
-        find "./src/${{ inputs.image }}" -type f -exec sed -i "s/base:local/base:$FIRST_TAG/g" {} +
+        echo "base-image-tag=$FIRST_TAG" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Authenticate with registry
@@ -108,6 +108,8 @@ runs:
 
     - name: Build devcontainer
       uses: devcontainers/ci@v0.3
+      env:
+        BASE_IMAGE_TAG: ${{ steps.set-base-image-tag.outputs.base-image-tag }}
       with:
         imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
         imageTag: ${{ steps.extract-tag-parts.outputs.tags }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -18,16 +18,9 @@ inputs:
     description: 'Docker registry'
     required: false
     default: ghcr.io
-  component-name:
-    description: Name of the component
-    required: false
   github-token:
     description: GitHub token
     required: true
-  enable-component-version:
-    description: Enable component version
-    required: false
-    default: 'true'
 
 runs:
   using: composite

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -10,6 +10,10 @@ inputs:
   base-image-tag:
     description: Base image tag to use for child image builds
     required: true
+  push-image:
+    description: Push the built image to the registry (when false, loads base image from artifact instead)
+    required: false
+    default: 'false'
   registry:
     description: 'Docker registry'
     required: false
@@ -28,18 +32,28 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout (GitHub)
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      with:
-        fetch-depth: 0
 
     - name: Authenticate with registry
-      if: github.event_name != 'pull_request'
+      if: inputs.push-image == 'true'
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
+
+    - name: Download base image artifact
+      if: inputs.push-image != 'true'
+      uses: actions/download-artifact@v4
+      with:
+        name: base
+
+    - name: Load base image artifact
+      if: inputs.push-image != 'true'
+      run: |
+        gunzip -c base.tar.gz | docker load
+        IMAGE="ghcr.io/${{ github.repository }}/base:${{ inputs.base-image-tag }}"
+        docker image inspect "$IMAGE" >/dev/null 2>&1
+      shell: bash
 
     - name: Build devcontainer
       uses: devcontainers/ci@v0.3
@@ -48,5 +62,6 @@ runs:
       with:
         imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
         imageTag: ${{ inputs.image-tags }}
+        push: ${{ inputs.push-image == 'true' && 'always' || 'never' }}
         subFolder: ./src/${{ inputs.image }}
         cacheFrom: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
 
-    - name: Authenticate with registry
+    - name: Log in to registry
       if: inputs.push-image == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
@@ -40,7 +40,7 @@ runs:
       with:
         name: base
 
-    - name: Load base image artifact
+    - name: Load base image from artifact
       if: inputs.push-image != 'true'
       run: |
         gunzip -c base.tar.gz | docker load
@@ -48,7 +48,7 @@ runs:
         docker image inspect "$IMAGE" >/dev/null 2>&1
       shell: bash
 
-    - name: Build devcontainer
+    - name: Build devcontainer image
       uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
       env:
         BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -4,6 +4,12 @@ inputs:
   image:
     description: Name of the image to build
     required: true
+  image-tags:
+    description: Comma-separated tags to apply to the image
+    required: true
+  base-image-tag:
+    description: Base image tag to use for child image builds
+    required: true
   registry:
     description: 'Docker registry'
     required: false
@@ -27,77 +33,6 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Install gitversion
-      uses: gittools/actions/gitversion/setup@a2825198c355443479ad391aa9d8ba78aa8007ac
-      with:
-        versionSpec: 5.12.0
-
-    - name: Determine version number
-      id: gitversion
-      uses: gittools/actions/gitversion/execute@a2825198c355443479ad391aa9d8ba78aa8007ac
-
-    - name: Determine component name
-      id: component-name
-      run: |
-        NAME="${{ inputs.component-name }}"
-          if [ -z "$NAME" ]; then
-            NAME="${{ inputs.image }}"
-          fi
-          echo "name=${NAME}" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Extract component version from devcontainer.json
-      id: component-version
-      run: |
-        DEVCONTAINER_FILE=./src/${{ inputs.image }}/.devcontainer/devcontainer.json
-        if [[ -f "$DEVCONTAINER_FILE" ]]; then
-          VERSION=$(jq -r '.features | to_entries[0].value.version' $DEVCONTAINER_FILE)
-          if [[ "$VERSION" != "null" ]]; then
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            echo "version-found=true" >> $GITHUB_OUTPUT
-          else
-            echo "Key does not exist in $DEVCONTAINER_FILE."
-          fi
-        else
-          echo "$DEVCONTAINER_FILE does not exist."
-        fi
-      shell: bash
-
-    - name: Determine image tags using Docker metadata action
-      id: metadata
-      uses: docker/metadata-action@v5
-      with:
-        images: ghcr.io/${{ github.repository }}
-        tags: |
-          type=raw,value=${{ steps.gitversion.outputs.semVer }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-          type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-          type=raw,value=${{ steps.gitversion.outputs.major }},enable=${{ steps.gitversion.outputs.major != '0' && endsWith(github.ref, github.event.repository.default_branch) }}
-          type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-{{sha}}
-          type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-${{ steps.gitversion.outputs.sha }}
-          type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.component-name.outputs.name }}${{ steps.component-version.outputs.version }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) && steps.component-version.outputs.version-found == 'true' }}
-          type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}-${{ steps.component-name.outputs.name }}${{ steps.component-version.outputs.version }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) && steps.component-version.outputs.version-found == 'true' }}
-          type=raw,value=${{ steps.gitversion.outputs.major }}-${{ steps.component-name.outputs.name }}${{ steps.component-version.outputs.version }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) && steps.component-version.outputs.version-found == 'true' }}
-          type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-{{sha}}-${{ steps.component-name.outputs.name }}${{ steps.component-version.outputs.version }},enable=${{ steps.component-version.outputs.version-found == 'true' }}
-          type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-${{ steps.gitversion.outputs.sha }}-${{ steps.component-name.outputs.name }}${{ steps.component-version.outputs.version }},enable=${{ steps.component-version.outputs.version-found == 'true' }}
-          type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-          type=ref,event=branch
-          type=ref,event=pr
-
-    - name: Extract only tag part of full image name
-      id: extract-tag-parts
-      run: |
-        TAGS=$(echo '${{ steps.metadata.outputs.json }}' | jq -r '[.tags[] | split(":") | last] | join(",")')
-        echo "$TAGS"
-        echo "tags=$TAGS" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Determine base image tag
-      id: set-base-image-tag
-      run: |
-        FIRST_TAG=$(echo "${{ steps.extract-tag-parts.outputs.tags }}" | cut -d',' -f1)
-        echo "base-image-tag=$FIRST_TAG" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Authenticate with registry
       if: github.event_name != 'pull_request'
       uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
@@ -109,9 +44,9 @@ runs:
     - name: Build devcontainer
       uses: devcontainers/ci@v0.3
       env:
-        BASE_IMAGE_TAG: ${{ steps.set-base-image-tag.outputs.base-image-tag }}
+        BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}
       with:
         imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
-        imageTag: ${{ steps.extract-tag-parts.outputs.tags }}
+        imageTag: ${{ inputs.image-tags }}
         subFolder: ./src/${{ inputs.image }}
         cacheFrom: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -48,13 +48,50 @@ runs:
         docker image inspect "$IMAGE" >/dev/null 2>&1
       shell: bash
 
+    - name: Extract component version from devcontainer.json
+      id: component-version
+      run: |
+        DEVCONTAINER_FILE=./src/${{ inputs.image }}/.devcontainer/devcontainer.json
+        if [[ -f "$DEVCONTAINER_FILE" ]]; then
+          VERSION=$(jq -r '.features | to_entries[0].value.version' "$DEVCONTAINER_FILE")
+          if [[ "$VERSION" != "null" && -n "$VERSION" ]]; then
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "version-found=true" >> $GITHUB_OUTPUT
+          else
+            echo "No version key found in $DEVCONTAINER_FILE."
+          fi
+        else
+          echo "$DEVCONTAINER_FILE does not exist."
+        fi
+      shell: bash
+
+    - name: Add component-version tags
+      id: augment-tags
+      run: |
+        TAGS="${{ inputs.image-tags }}"
+
+        if [[ "${{ steps.component-version.outputs.version-found }}" == "true" ]]; then
+          SUFFIX="${{ inputs.image }}${{ steps.component-version.outputs.version }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+          for TAG in "${TAG_ARRAY[@]}"; do
+            if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+               [[ "$TAG" =~ ^[0-9]+\.[0-9]+$ ]] || \
+               [[ "$TAG" =~ ^[0-9]+$ ]]; then
+              TAGS="${TAGS},${TAG}-${SUFFIX}"
+            fi
+          done
+        fi
+
+        echo "tags=$TAGS" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Build devcontainer image
       uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
       env:
         BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}
       with:
         imageName: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}
-        imageTag: ${{ inputs.image-tags }}
+        imageTag: ${{ steps.augment-tags.outputs.tags }}
         push: ${{ inputs.push-image == 'true' && 'always' || 'never' }}
         subFolder: ./src/${{ inputs.image }}
         cacheFrom: ${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image }}

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -43,7 +43,7 @@ runs:
 
     - name: Download base image artifact
       if: inputs.push-image != 'true'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: base
 
@@ -56,7 +56,7 @@ runs:
       shell: bash
 
     - name: Build devcontainer
-      uses: devcontainers/ci@v0.3
+      uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
       env:
         BASE_IMAGE_TAG: ${{ inputs.base-image-tag }}
       with:

--- a/.github/actions/publish-devcontainer/action.yaml
+++ b/.github/actions/publish-devcontainer/action.yaml
@@ -35,7 +35,7 @@ runs:
 
     - name: Authenticate with registry
       if: inputs.push-image == 'true'
-      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -1,4 +1,4 @@
-name: Publish devcontainers
+name: Build devcontainers
 
 on:
   pull_request:
@@ -61,8 +61,8 @@ jobs:
           echo "base-image-tag=$FIRST_TAG" >> $GITHUB_OUTPUT
         shell: bash
 
-  publish-base:
-    name: Publish base
+  build-base:
+    name: Build base
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,22 +73,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Log in to registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+      - name: Build base devcontainer
+        uses: ./.github/actions/build-devcontainer
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build base devcontainer image
-        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
-        with:
-          imageName: ghcr.io/${{ github.repository }}/base
-          imageTag: ${{ needs.prepare-tags.outputs.tags }}
-          push: ${{ github.event_name != 'pull_request' && 'always' || 'never' }}
-          subFolder: ./src/base
-          cacheFrom: ghcr.io/${{ github.repository }}/base
+          image: base
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          push-image: ${{ github.event_name != 'pull_request' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Export base image for dependent jobs
         if: github.event_name == 'pull_request'
@@ -107,15 +98,15 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-images:
-    name: Publish ${{ matrix.image }}
+  build-child-images:
+    name: Build ${{ matrix.image }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     needs:
       - prepare-tags
-      - publish-base
+      - build-base
     strategy:
       fail-fast: false
       matrix:
@@ -124,8 +115,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Publish ${{ matrix.image }} devcontainer
-        uses: ./.github/actions/publish-devcontainer
+      - name: Build ${{ matrix.image }} devcontainer
+        uses: ./.github/actions/build-child-devcontainer
         with:
           image: ${{ matrix.image }}
           image-tags: ${{ needs.prepare-tags.outputs.tags }}

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -48,8 +48,10 @@ jobs:
 
       - name: Strip image name from tags
         id: extract-tag-parts
+        env:
+          METADATA_JSON: ${{ steps.metadata.outputs.json }}
         run: |
-          TAGS=$(echo '${{ steps.metadata.outputs.json }}' | jq -r '[.tags[] | split(":") | last] | join(",")')
+          TAGS=$(echo "$METADATA_JSON" | jq -r '[.tags[] | split(":") | last] | join(",")')
           echo "$TAGS"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -75,6 +75,23 @@ jobs:
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Save base image for PR child jobs
+        if: github.event_name == 'pull_request'
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+          docker save "$IMAGE" | gzip > base-image.tar.gz
+        shell: bash
+
+      - name: Upload base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-image
+          path: base-image.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
   publish-dotnet:
     runs-on: ubuntu-latest
     needs:
@@ -83,6 +100,20 @@ jobs:
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Download base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image
+
+      - name: Load base image artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          gunzip -c base-image.tar.gz | docker load
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+        shell: bash
 
       - name: Publish dotnet devcontainer
         uses: ./.github/actions/publish-devcontainer
@@ -101,6 +132,20 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
+      - name: Download base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image
+
+      - name: Load base image artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          gunzip -c base-image.tar.gz | docker load
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+        shell: bash
+
       - name: Publish go devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
@@ -117,6 +162,20 @@ jobs:
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Download base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image
+
+      - name: Load base image artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          gunzip -c base-image.tar.gz | docker load
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+        shell: bash
 
       - name: Publish dotnet devcontainer
         uses: ./.github/actions/publish-devcontainer
@@ -135,6 +194,20 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
+      - name: Download base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image
+
+      - name: Load base image artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          gunzip -c base-image.tar.gz | docker load
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+        shell: bash
+
       - name: Publish dotnet devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
@@ -152,6 +225,20 @@ jobs:
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Download base image artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image
+
+      - name: Load base image artifact
+        if: github.event_name == 'pull_request'
+        run: |
+          gunzip -c base-image.tar.gz | docker load
+          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
+          docker image inspect "$IMAGE" >/dev/null 2>&1
+        shell: bash
 
       - name: Publish dotnet devcontainer
         uses: ./.github/actions/publish-devcontainer

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Authenticate with registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   prepare-tags:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tags: ${{ steps.extract-tag-parts.outputs.tags }}
       base-image-tag: ${{ steps.set-base-image-tag.outputs.base-image-tag }}
@@ -60,6 +62,9 @@ jobs:
 
   publish-base:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - prepare-tags
     steps:
@@ -102,6 +107,9 @@ jobs:
 
   publish-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - prepare-tags
       - publish-base

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish base devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: base
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: dotnet
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish go devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: go
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: hugo
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: javascript
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@main
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: python
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -15,8 +15,8 @@ jobs:
       tags: ${{ steps.extract-tag-parts.outputs.tags }}
       base-image-tag: ${{ steps.set-base-image-tag.outputs.base-image-tag }}
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -64,31 +64,40 @@ jobs:
     needs:
       - prepare-tags
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Publish base devcontainer
-        uses: ./.github/actions/publish-devcontainer
+      - name: Authenticate with registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
-          image: base
-          image-tags: ${{ needs.prepare-tags.outputs.tags }}
-          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Save base image for PR child jobs
+      - name: Build base devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository }}/base
+          imageTag: ${{ needs.prepare-tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' && 'always' || 'never' }}
+          subFolder: ./src/base
+          cacheFrom: ghcr.io/${{ github.repository }}/base
+
+      - name: Save base image for child jobs
         if: github.event_name == 'pull_request'
         run: |
           IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
           docker image inspect "$IMAGE" >/dev/null 2>&1
-          docker save "$IMAGE" | gzip > base-image.tar.gz
+          docker save "$IMAGE" | gzip > base.tar.gz
         shell: bash
 
       - name: Upload base image artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: base-image
-          path: base-image.tar.gz
+          name: base
+          path: base.tar.gz
           if-no-files-found: error
           retention-days: 1
 
@@ -98,22 +107,8 @@ jobs:
       - prepare-tags
       - publish-base
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-
-      - name: Download base image artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: base-image
-
-      - name: Load base image artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          gunzip -c base-image.tar.gz | docker load
-          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
-          docker image inspect "$IMAGE" >/dev/null 2>&1
-        shell: bash
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Publish dotnet devcontainer
         uses: ./.github/actions/publish-devcontainer
@@ -121,6 +116,7 @@ jobs:
           image: dotnet
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
+          push-image: ${{ github.event_name != 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-go:
@@ -129,22 +125,8 @@ jobs:
       - prepare-tags
       - publish-base
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-
-      - name: Download base image artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: base-image
-
-      - name: Load base image artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          gunzip -c base-image.tar.gz | docker load
-          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
-          docker image inspect "$IMAGE" >/dev/null 2>&1
-        shell: bash
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Publish go devcontainer
         uses: ./.github/actions/publish-devcontainer
@@ -152,6 +134,7 @@ jobs:
           image: go
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
+          push-image: ${{ github.event_name != 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-hugo:
@@ -160,29 +143,16 @@ jobs:
       - prepare-tags
       - publish-base
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Download base image artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: base-image
-
-      - name: Load base image artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          gunzip -c base-image.tar.gz | docker load
-          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
-          docker image inspect "$IMAGE" >/dev/null 2>&1
-        shell: bash
-
-      - name: Publish dotnet devcontainer
+      - name: Publish hugo devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
           image: hugo
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
+          push-image: ${{ github.event_name != 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-javascript:
@@ -191,29 +161,16 @@ jobs:
       - prepare-tags
       - publish-base
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Download base image artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: base-image
-
-      - name: Load base image artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          gunzip -c base-image.tar.gz | docker load
-          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
-          docker image inspect "$IMAGE" >/dev/null 2>&1
-        shell: bash
-
-      - name: Publish dotnet devcontainer
+      - name: Publish javascript devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
           image: javascript
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
+          push-image: ${{ github.event_name != 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: node
 
@@ -223,29 +180,16 @@ jobs:
       - prepare-tags
       - publish-base
     steps:
-      - name: Checkout (GitHub)
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Download base image artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@v4
-        with:
-          name: base-image
-
-      - name: Load base image artifact
-        if: github.event_name == 'pull_request'
-        run: |
-          gunzip -c base-image.tar.gz | docker load
-          IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
-          docker image inspect "$IMAGE" >/dev/null 2>&1
-        shell: bash
-
-      - name: Publish dotnet devcontainer
+      - name: Publish python devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
           image: python
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
+          push-image: ${{ github.event_name != 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-workflows:

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -22,16 +22,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install gitversion
+      - name: Set up GitVersion
         uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8
         with:
           versionSpec: 6.7.0
 
-      - name: Determine version number
+      - name: Determine version
         id: gitversion
         uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8
 
-      - name: Determine image tags using Docker metadata action
+      - name: Generate image tags
         id: metadata
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
@@ -45,7 +45,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
 
-      - name: Extract only tag part of full image name
+      - name: Strip image name from tags
         id: extract-tag-parts
         run: |
           TAGS=$(echo '${{ steps.metadata.outputs.json }}' | jq -r '[.tags[] | split(":") | last] | join(",")')
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Authenticate with registry
+      - name: Log in to registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
@@ -79,7 +79,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build base devcontainer
+      - name: Build base devcontainer image
         uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
         with:
           imageName: ghcr.io/${{ github.repository }}/base
@@ -88,7 +88,7 @@ jobs:
           subFolder: ./src/base
           cacheFrom: ghcr.io/${{ github.repository }}/base
 
-      - name: Save base image for child jobs
+      - name: Export base image for dependent jobs
         if: github.event_name == 'pull_request'
         run: |
           IMAGE="ghcr.io/${{ github.repository }}/base:${{ needs.prepare-tags.outputs.base-image-tag }}"
@@ -96,7 +96,7 @@ jobs:
           docker save "$IMAGE" | gzip > base.tar.gz
         shell: bash
 
-      - name: Upload base image artifact
+      - name: Upload base image as artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -136,7 +136,7 @@ jobs:
       actions: write
       contents: read
     steps:
-      - name: Delete workflow runs
+      - name: Delete old workflow runs
         uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee
         with:
           token: ${{ github.token }}

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish base devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: base
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: dotnet
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish go devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: go
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: hugo
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: javascript
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
       - publish-base
     steps:
       - name: Publish dotnet devcontainer
-        uses: ./.github/actions/publish-devcontainer
+        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
         with:
           image: python
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -35,11 +35,11 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ steps.gitversion.outputs.semVer }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=raw,value=${{ steps.gitversion.outputs.major }},enable=${{ steps.gitversion.outputs.major != '0' && endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.semVer }},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.major }},enable=${{ steps.gitversion.outputs.major != '0' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-{{sha}}
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=ref,event=branch
             type=ref,event=pr
 

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -101,92 +101,23 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-dotnet:
+  publish-images:
     runs-on: ubuntu-latest
     needs:
       - prepare-tags
       - publish-base
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [dotnet, go, hugo, javascript, python]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - name: Publish dotnet devcontainer
+      - name: Publish ${{ matrix.image }} devcontainer
         uses: ./.github/actions/publish-devcontainer
         with:
-          image: dotnet
-          image-tags: ${{ needs.prepare-tags.outputs.tags }}
-          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
-          push-image: ${{ github.event_name != 'pull_request' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-go:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-tags
-      - publish-base
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Publish go devcontainer
-        uses: ./.github/actions/publish-devcontainer
-        with:
-          image: go
-          image-tags: ${{ needs.prepare-tags.outputs.tags }}
-          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
-          push-image: ${{ github.event_name != 'pull_request' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-hugo:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-tags
-      - publish-base
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Publish hugo devcontainer
-        uses: ./.github/actions/publish-devcontainer
-        with:
-          image: hugo
-          image-tags: ${{ needs.prepare-tags.outputs.tags }}
-          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
-          push-image: ${{ github.event_name != 'pull_request' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-javascript:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-tags
-      - publish-base
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Publish javascript devcontainer
-        uses: ./.github/actions/publish-devcontainer
-        with:
-          image: javascript
-          image-tags: ${{ needs.prepare-tags.outputs.tags }}
-          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
-          push-image: ${{ github.event_name != 'pull_request' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          component-name: node
-
-  publish-python:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-tags
-      - publish-base
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Publish python devcontainer
-        uses: ./.github/actions/publish-devcontainer
-        with:
-          image: python
+          image: ${{ matrix.image }}
           image-tags: ${{ needs.prepare-tags.outputs.tags }}
           base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           push-image: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   prepare-tags:
+    name: Prepare tags
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,6 +62,7 @@ jobs:
         shell: bash
 
   publish-base:
+    name: Publish base
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,6 +108,7 @@ jobs:
           retention-days: 1
 
   publish-images:
+    name: Publish ${{ matrix.image }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -131,6 +134,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-workflows:
+    name: Cleanup workflows
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Determine image tags using Docker metadata action
         id: metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -76,7 +76,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build base devcontainer
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5
         with:
           imageName: ghcr.io/${{ github.repository }}/base
           imageTag: ${{ needs.prepare-tags.outputs.tags }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload base image artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: base
           path: base.tar.gz

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -21,13 +21,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install gitversion
-        uses: gittools/actions/gitversion/setup@a2825198c355443479ad391aa9d8ba78aa8007ac
+        uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8
         with:
-          versionSpec: 5.12.0
+          versionSpec: 6.7.0
 
       - name: Determine version number
         id: gitversion
-        uses: gittools/actions/gitversion/execute@a2825198c355443479ad391aa9d8ba78aa8007ac
+        uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8
 
       - name: Determine image tags using Docker metadata action
         id: metadata

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -9,69 +9,156 @@ on:
       - '*'
 
 jobs:
+  prepare-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.extract-tag-parts.outputs.tags }}
+      base-image-tag: ${{ steps.set-base-image-tag.outputs.base-image-tag }}
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
+
+      - name: Install gitversion
+        uses: gittools/actions/gitversion/setup@a2825198c355443479ad391aa9d8ba78aa8007ac
+        with:
+          versionSpec: 5.12.0
+
+      - name: Determine version number
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@a2825198c355443479ad391aa9d8ba78aa8007ac
+
+      - name: Determine image tags using Docker metadata action
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.gitversion.outputs.semVer }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.major }},enable=${{ steps.gitversion.outputs.major != '0' && endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-{{sha}}
+            type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-${{ steps.gitversion.outputs.sha }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Extract only tag part of full image name
+        id: extract-tag-parts
+        run: |
+          TAGS=$(echo '${{ steps.metadata.outputs.json }}' | jq -r '[.tags[] | split(":") | last] | join(",")')
+          echo "$TAGS"
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Determine base image tag
+        id: set-base-image-tag
+        run: |
+          FIRST_TAG=$(echo "${{ steps.extract-tag-parts.outputs.tags }}" | cut -d',' -f1)
+          echo "base-image-tag=$FIRST_TAG" >> $GITHUB_OUTPUT
+        shell: bash
+
   publish-base:
     runs-on: ubuntu-latest
+    needs:
+      - prepare-tags
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish base devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: base
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-dotnet:
     runs-on: ubuntu-latest
     needs:
+      - prepare-tags
       - publish-base
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: dotnet
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-go:
     runs-on: ubuntu-latest
     needs:
+      - prepare-tags
       - publish-base
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish go devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: go
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-hugo:
     runs-on: ubuntu-latest
     needs:
+      - prepare-tags
       - publish-base
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: hugo
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-javascript:
     runs-on: ubuntu-latest
     needs:
+      - prepare-tags
       - publish-base
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: javascript
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: node
 
   publish-python:
     runs-on: ubuntu-latest
     needs:
+      - prepare-tags
       - publish-base
     steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Publish dotnet devcontainer
-        uses: iaingalloway/devcontainers/.github/actions/publish-devcontainer@121fe35714d04b5359994afd4aa77512b2825d6f
+        uses: ./.github/actions/publish-devcontainer
         with:
           image: python
+          image-tags: ${{ needs.prepare-tags.outputs.tags }}
+          base-image-tag: ${{ needs.prepare-tags.outputs.base-image-tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-workflows:

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -193,15 +193,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-workflows:
-      runs-on: ubuntu-latest
-      permissions:
-        actions: write
-        contents: read
-      steps:
-        - name: Delete workflow runs
-          uses: Mattraks/delete-workflow-runs@39f0bbed25d76b34de5594dceab824811479e5de
-          with:
-            token: ${{ github.token }}
-            repository: ${{ github.repository }}
-            retain_days: 30
-            keep_minimum_runs: 5
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 30
+          keep_minimum_runs: 5

--- a/.github/workflows/publish-devcontainers.yaml
+++ b/.github/workflows/publish-devcontainers.yaml
@@ -39,7 +39,6 @@ jobs:
             type=raw,value=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value=${{ steps.gitversion.outputs.major }},enable=${{ steps.gitversion.outputs.major != '0' && endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-{{sha}}
-            type=raw,value=${{ steps.gitversion.outputs.semVer }}-${{ steps.gitversion.outputs.branchName }}-${{ steps.gitversion.outputs.commitsSinceVersionSource }}-${{ steps.gitversion.outputs.sha }}
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=ref,event=branch
             type=ref,event=pr

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,8 @@
-mode: Mainline
+workflow: GitHubFlow/v1
+mode: ContinuousDeployment
+strategies:
+  - ConfiguredNextVersion
+  - Mainline
+branches:
+  main:
+    increment: Patch

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following images are available:
 ```json
 {
   "name": "My Awesome Project Devcontainer",
-  "image": "ghcr.io/iaingalloway/devcontainers/dotnet::1.4-dotnet10.0.101",
+  "image": "ghcr.io/iaingalloway/devcontainers/dotnet:1.4-dotnet10.0.101",
   "runArgs": [
     "--name",
     "my-awesome-project-devcontainer",

--- a/src/dotnet/.devcontainer/devcontainer.json
+++ b/src/dotnet/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
       }
     }
   },
-  "image": "ghcr.io/iaingalloway/devcontainers/base:local",
+  "image": "ghcr.io/iaingalloway/devcontainers/base:${localEnv:BASE_IMAGE_TAG:local}",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:2.5.0": {
       "version": "10.0.201"

--- a/src/go/.devcontainer/devcontainer.json
+++ b/src/go/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       ]
     }
   },
-  "image": "ghcr.io/iaingalloway/devcontainers/base:local",
+  "image": "ghcr.io/iaingalloway/devcontainers/base:${localEnv:BASE_IMAGE_TAG:local}",
   "features": {
     "ghcr.io/devcontainers/features/go:1.3.3": {
       "version": "1.26.0"

--- a/src/hugo/.devcontainer/devcontainer.json
+++ b/src/hugo/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       ]
     }
   },
-  "image": "ghcr.io/iaingalloway/devcontainers/base:local",
+  "image": "ghcr.io/iaingalloway/devcontainers/base:${localEnv:BASE_IMAGE_TAG:local}",
   "features": {
     "ghcr.io/devcontainers/features/hugo:1.1.3": {
       "version": "0.153.0",

--- a/src/javascript/.devcontainer/devcontainer.json
+++ b/src/javascript/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       ]
     }
   },
-  "image": "ghcr.io/iaingalloway/devcontainers/base:local",
+  "image": "ghcr.io/iaingalloway/devcontainers/base:${localEnv:BASE_IMAGE_TAG:local}",
   "features": {
     "ghcr.io/devcontainers/features/node:1.7.1": {
       "version": "25.8.1"

--- a/src/python/.devcontainer/devcontainer.json
+++ b/src/python/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       ]
     }
   },
-  "image": "ghcr.io/iaingalloway/devcontainers/base:local",
+  "image": "ghcr.io/iaingalloway/devcontainers/base:${localEnv:BASE_IMAGE_TAG:local}",
   "features": {
     "ghcr.io/devcontainers/features/python:1.8.0": {
       "version": "3.14.3"


### PR DESCRIPTION
Closes #11 

Currently, the GHA workflow uses sed to rewrite devcontainer.json - this is inelegant and potentially bad for caching

Instead we'll use environment variable substitution.